### PR TITLE
rework news component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,3 @@
 <div>
-  <app-country-select></app-country-select>
   <app-news></app-news>
 </div>

--- a/src/app/components/country-select/country-select.component.html
+++ b/src/app/components/country-select/country-select.component.html
@@ -1,4 +1,4 @@
-<select [(ngModel)]="selectedCountry" (change)="onChange($event.target.value)">
+Selected Region:
+<select [value]="countries[0]" (change)="onChange($event.target.value)">
   <option *ngFor="let country of countries" [value]="country">{{country}}</option>
 </select>
-<p>{{selectedCountry}}</p>

--- a/src/app/components/country-select/country-select.component.ts
+++ b/src/app/components/country-select/country-select.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit, Inject } from '@angular/core';
-import { NewsService } from 'src/app/services/news.service';
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-country-select',
@@ -7,16 +6,16 @@ import { NewsService } from 'src/app/services/news.service';
   styleUrls: ['./country-select.component.scss']
 })
 export class CountrySelectComponent implements OnInit {
-  countries = ['global', 'GB'];
-  selectedCountry: string = this.countries[0];
+  @Input() countries : string[];
+  @Output() selectedCountry = new EventEmitter<string>();
 
-  constructor(@Inject('NewsService') private newsService: NewsService) { }
+  constructor() { }
 
   onChange(value: string): void {
-    this.newsService.changeRegion(value);
+    console.log(`Country Select Component: ${value}`);
+    this.selectedCountry.emit(value);
   }
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void { }
 
 }

--- a/src/app/components/news/news.component.html
+++ b/src/app/components/news/news.component.html
@@ -1,3 +1,7 @@
+<app-country-select 
+  [countries]="countries" 
+  (selectedCountry)="onCountryChange($event)">
+</app-country-select>
 <h1>News</h1>
 <ul>
   <li *ngFor="let newsItem of news">

--- a/src/app/components/news/news.component.ts
+++ b/src/app/components/news/news.component.ts
@@ -9,24 +9,23 @@ import { News } from '../../models/News';
 })
 export class NewsComponent implements OnInit {
   news: News[];
-  region: string;
-  subscription: any;
+  countries = ['global', 'GB'];  
 
   constructor(@Inject('NewsService') private newsService: NewsService) {}
 
   ngOnInit(): void {
-    this.subscription = this.newsService.getNews().subscribe(
+    this.getNews(this.countries[0]);
+  }
+
+  onCountryChange(country: string) {
+    this.getNews(country);
+  }
+
+  getNews(region: string): void {
+    this.newsService.getNews(region).subscribe(
       news => {
         this.news = news;
       });
-    this.newsService.getRegionSwitcher().subscribe(region =>
-    {
-      this.subscription.unsubscribe();
-      this.subscription = this.newsService.getNews().subscribe(
-      news => {
-        this.news = news;
-      });
-    });
   }
 
 }

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -1,38 +1,36 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, from, Subject } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { News } from '../models/News';
 
 export interface NewsService {
-  getNews(): Observable<News[]>;
-  getRegionSwitcher(): Subject<string>;
-  changeRegion(region: string): void;
+  getNews(region: string): Observable<News[]>;
 }
 
-@Injectable({
-  providedIn: 'root'
-})
-export class DummyNewsService implements NewsService {
-  getRegionSwitcher(): Subject<string> {
-    return new Subject<string>();
-  }
-  changeRegion(region: string): void {}
-  getNews(): Observable<News[]>  {
-    return from([[
-      {
-        url: 'http://www.google.com',
-        title: 'COVID kills',
-        description: 'Dumb ppl still not wearing masks.'
-      },
-      {
-        url: 'http://www.bridgebase.com/v3',
-        title: 'Moron dies after injecting himself with bleach',
-        description: 'Trump claims injecting bleach as a COVID treatment is "very, very bad"'
-      }
-    ]]);
-  }
-}
+// @Injectable({
+//   providedIn: 'root'
+// })
+// export class DummyNewsService implements NewsService {
+//   getRegionSwitcher(): Subject<string> {
+//     return new Subject<string>();
+//   }
+//   changeRegion(region: string): void {}
+//   getNews(): Observable<News[]>  {
+//     return from([[
+//       {
+//         url: 'http://www.google.com',
+//         title: 'COVID kills',
+//         description: 'Dumb ppl still not wearing masks.'
+//       },
+//       {
+//         url: 'http://www.bridgebase.com/v3',
+//         title: 'Moron dies after injecting himself with bleach',
+//         description: 'Trump claims injecting bleach as a COVID treatment is "very, very bad"'
+//       }
+//     ]]);
+//   }
+// }
 
 @Injectable({
   providedIn: 'root'
@@ -40,18 +38,13 @@ export class DummyNewsService implements NewsService {
 export class ActualNewsService implements NewsService {
   url = 'https://api.smartable.ai/coronavirus/news/';
   subscriptionKey = '955eacf9525e45dd8d46a07b7daa649e';
-  region = 'global';
-  regionSwitcher: Subject<string>;
 
-  constructor(private httpClient: HttpClient) {
-    this.regionSwitcher = new Subject<string>();
-    this.regionSwitcher.next(this.region);
-  }
+  constructor(private httpClient: HttpClient) { }
 
-  getNews(): Observable<News[]> {
+  getNews(region = 'global'): Observable<News[]> {
     return this.httpClient
       .get(
-        this.url + this.region,
+        this.url + region,
         {
           headers: { 'Subscription-Key': this.subscriptionKey }
         })
@@ -63,14 +56,5 @@ export class ActualNewsService implements NewsService {
           description: excerpt
         }))
       ));
-  }
-
-  changeRegion(region: string): void {
-    this.region = region;
-    this.regionSwitcher.next(region);
-  }
-
-  getRegionSwitcher(): Subject<string> {
-    return this.regionSwitcher;
   }
 }


### PR DESCRIPTION
Ok, so here is my proposed changes to the way you were doing things:

- The country select component is now a child component of the news component. Nesting it feels like it fits better, as its function directly relates to the news component. Nesting it allows for the `@Input` and `@Output` decorates, which feels like a better way to pass information between the two. 

- As an aside, the country select component is now generic, so the countries are passed in it emits the selected values. Its not even necessarily a country selector anymore and might need a rename to reflect that.

- Its probably cleaner to change it from an array of strings to an array of objects with a name and value, eg `{ name: 'Great Britain, value: 'GB }`, one for displaying and one for using with the api. I haven't done this just in the name of getting this working. I'd also consider moving the array of countries to the news component, as the mapping is specific to the api we're using? (but probably still pass it in via to the selector via `@Input` instead of dependency injection to keep the component generic)

- `getNews` in the service now takes a region parameter. This might need some form of error handling/validation. The method is called once in `onInit`, and then subsequently by the `onCountryChange` event handler. Worth noting is that you don't have to unsubscribe to the `HttpClient`'s `get` method, as it returns a [finite observable](https://stackoverflow.com/questions/35042929/is-it-necessary-to-unsubscribe-from-observables-created-by-http-methods)

- I've removed the now unnecessary stuff from the `NewsServiceInterface`, so no more region switcher

Took a bit longer to get around to this, Adrian was right about the C# course DB setup being annoying. Hopefully this is helpful!