### PR TITLE
Feature/22 historical data api service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,8 +10,9 @@ import { WorldMapComponent } from './components/world-map/world-map.component';
 
 import { OpenStreetMapProvider } from './services/map-provider.service';
 
-import { COVID_DATA_API_SUB_SERVICE } from './services/covid-data-api.service';
-import { Covid19ApiService } from './services/externalApis/covid-19-api.service';
+import { COVID_DATA_API_SUB_SERVICE_SUMMARY, COVID_DATA_API_SUB_SERVICE_HISTORICAL } from './services/covid-data-api.service';
+import { SummaryCovid19ApiService } from './services/externalApis/summary-covid-19-api.service';
+import { HistoricalCovid19ApiService } from './services/externalApis/historical-covid-19-api.service';
 
 @NgModule({
   declarations: [AppComponent, CountriesTableComponent, WorldMapComponent],
@@ -21,8 +22,13 @@ import { Covid19ApiService } from './services/externalApis/covid-19-api.service'
   providers: [
     { provide: 'MapProvider', useClass: OpenStreetMapProvider },
     {
-      provide: COVID_DATA_API_SUB_SERVICE,
-      useClass: Covid19ApiService,
+      provide: COVID_DATA_API_SUB_SERVICE_SUMMARY,
+      useClass: SummaryCovid19ApiService,
+      multi: true,
+    },
+    {
+      provide: COVID_DATA_API_SUB_SERVICE_HISTORICAL,
+      useClass: HistoricalCovid19ApiService,
       multi: true,
     },
   ],

--- a/src/app/services/covid-data-api.service.spec.ts
+++ b/src/app/services/covid-data-api.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import {
   CovidDataApiService,
-  COVID_DATA_API_SUB_SERVICE,
+  COVID_DATA_API_SUB_SERVICE_SUMMARY,
   CovidDataApiSubService,
   missingCountryError,
   noGoodApiResponseError,
@@ -43,8 +43,8 @@ describe('CovidDataApiService', () => {
     // provide and inject spy/mock instead of dependency
     TestBed.configureTestingModule({
       providers: [
-        { provide: COVID_DATA_API_SUB_SERVICE, useValue: spy1, multi: true },
-        { provide: COVID_DATA_API_SUB_SERVICE, useValue: spy2, multi: true },
+        { provide: COVID_DATA_API_SUB_SERVICE_SUMMARY, useValue: spy1, multi: true },
+        { provide: COVID_DATA_API_SUB_SERVICE_SUMMARY, useValue: spy2, multi: true },
       ],
     });
 
@@ -53,7 +53,7 @@ describe('CovidDataApiService', () => {
     // Whenever we inject 'COVID_DATA_API_SUB_SERVICE' tokens,
     // we expect multiple services to be injected
     dependancyServiceSpies = TestBed.inject<CovidDataApiSubService[]>(
-      COVID_DATA_API_SUB_SERVICE
+      COVID_DATA_API_SUB_SERVICE_SUMMARY
     ) as jasmine.SpyObj<CovidDataApiSubService>[];
 
     dependancyServiceSpies.forEach((spy) => {

--- a/src/app/services/covid-data-api.service.ts
+++ b/src/app/services/covid-data-api.service.ts
@@ -2,9 +2,13 @@ import { Injectable, Inject, InjectionToken } from '@angular/core';
 import { CovidDataPoint } from '../models/CovidDataPoint';
 
 import { Subject } from 'rxjs';
+import { CountryHistoricalDataPoint } from './externalApis/common-covid-19-api';
 
 export interface CovidDataApiSubService {
-  call(successCallback: (x: any) => void, errorCallback: (x?: any) => void): void;
+  call(
+    successCallback: (x: any) => void,
+    errorCallback: (x?: any) => void
+  ): void;
 }
 
 export const COVID_DATA_API_SUB_SERVICE_SUMMARY = new InjectionToken<
@@ -19,12 +23,20 @@ export const COVID_DATA_API_SUB_SERVICE_HISTORICAL = new InjectionToken<
   providedIn: 'root',
 })
 export class CovidDataApiService {
-  summaryDataObserver: Subject<CovidDataPoint[]> = new Subject<CovidDataPoint[]>();
+  summaryDataObserver: Subject<CovidDataPoint[]> = new Subject<
+    CovidDataPoint[]
+  >();
+  historicalDataObserver: Subject<CountryHistoricalDataPoint[]> = new Subject<
+    CountryHistoricalDataPoint[]
+  >();
+
   constructor(
     // Inspired by (https://stackoverflow.com/a/35916788)
     // Each api service must have its own provider registered in app.module for the InjectionToken
     @Inject(COVID_DATA_API_SUB_SERVICE_SUMMARY)
-    private apiServices: CovidDataApiSubService[]
+    private summaryApiServices: CovidDataApiSubService[],
+    @Inject(COVID_DATA_API_SUB_SERVICE_HISTORICAL)
+    private historicalApiServices: CovidDataApiSubService[]
   ) {
     this.getCovidSummaryData();
   }
@@ -34,13 +46,25 @@ export class CovidDataApiService {
    * If all lead to errors, prints an error message to the console
    */
   private getCovidSummaryData(): void {
-    const callFunction = this.apiServices.reduceRight<(e?: any) => void>(
-      (fallback: () => void, api: CovidDataApiSubService) => () => api.call(
-        result => this.summaryDataObserver.next(result),
-        fallback
-      ),
-      () => console.error('All api sub-services responded with errors')
+    this.callApis(this.summaryApiServices, this.summaryDataObserver);
+  }
+
+  getCovidHistoricalData(): void {
+    this.callApis(this.historicalApiServices, this.historicalDataObserver);
+  }
+
+  private callApis = (
+    apiServices: CovidDataApiSubService[],
+    subject: Subject<any>
+  ) => {
+    const callFunction = apiServices.reduceRight<(e?: any) => void>(
+      (fallback: () => void, api: CovidDataApiSubService) => 
+          () => api.call(
+            (result) => subject.next(result), 
+            fallback
+          ),
+          () => console.error('All api sub-services responded with errors')
     );
     callFunction();
-  }
+  };
 }

--- a/src/app/services/covid-data-api.service.ts
+++ b/src/app/services/covid-data-api.service.ts
@@ -7,7 +7,11 @@ export interface CovidDataApiSubService {
   call(successCallback: (x: any) => void, errorCallback: (x?: any) => void): void;
 }
 
-export const COVID_DATA_API_SUB_SERVICE = new InjectionToken<
+export const COVID_DATA_API_SUB_SERVICE_SUMMARY = new InjectionToken<
+  CovidDataApiSubService
+>('CovidDataApiSubService');
+
+export const COVID_DATA_API_SUB_SERVICE_HISTORICAL = new InjectionToken<
   CovidDataApiSubService
 >('CovidDataApiSubService');
 
@@ -19,7 +23,7 @@ export class CovidDataApiService {
   constructor(
     // Inspired by (https://stackoverflow.com/a/35916788)
     // Each api service must have its own provider registered in app.module for the InjectionToken
-    @Inject(COVID_DATA_API_SUB_SERVICE)
+    @Inject(COVID_DATA_API_SUB_SERVICE_SUMMARY)
     private apiServices: CovidDataApiSubService[]
   ) {
     this.getCovidSummaryData();
@@ -38,5 +42,9 @@ export class CovidDataApiService {
       () => console.error('All api sub-services responded with errors')
     );
     callFunction();
+  }
+
+  private callFunction() {
+    
   }
 }

--- a/src/app/services/covid-data-api.service.ts
+++ b/src/app/services/covid-data-api.service.ts
@@ -4,6 +4,7 @@ import { CovidDataPoint } from '../models/CovidDataPoint';
 import { Subject } from 'rxjs';
 import { CountryHistoricalDataPoint } from './externalApis/common-covid-19-api';
 import { RegionSelectService } from './region-select.service';
+import { DateSelectService } from './date-select.service';
 
 export interface CovidDataApiSubService { 
   call(successCallback: (x: any) => void, errorCallback: (x?: any) => void): void;
@@ -32,10 +33,12 @@ export class CovidDataApiService {
     private summaryApiServices: CovidDataApiSubService[],
     @Inject(COVID_DATA_API_SUB_SERVICE_HISTORICAL)
     private historicalApiServices: CovidDataApiSubService[],
-    private regionService: RegionSelectService
+    private regionService: RegionSelectService,
+    private dateRangeService: DateSelectService
   ) {
     this.getCovidSummaryData();
-    regionService.getRegionObservable().subscribe(() => this.getCovidHistoricalData())
+    regionService.getRegionObservable().subscribe(() => this.getCovidHistoricalData());
+    dateRangeService.getDateRangeObservable().subscribe(() => this.getCovidHistoricalData());
   }
 
   /**

--- a/src/app/services/covid-data-api.service.ts
+++ b/src/app/services/covid-data-api.service.ts
@@ -3,6 +3,7 @@ import { CovidDataPoint } from '../models/CovidDataPoint';
 
 import { Subject } from 'rxjs';
 import { CountryHistoricalDataPoint } from './externalApis/common-covid-19-api';
+import { RegionSelectService } from './region-select.service';
 
 export interface CovidDataApiSubService {
   call(
@@ -36,9 +37,11 @@ export class CovidDataApiService {
     @Inject(COVID_DATA_API_SUB_SERVICE_SUMMARY)
     private summaryApiServices: CovidDataApiSubService[],
     @Inject(COVID_DATA_API_SUB_SERVICE_HISTORICAL)
-    private historicalApiServices: CovidDataApiSubService[]
+    private historicalApiServices: CovidDataApiSubService[],
+    private regionService: RegionSelectService
   ) {
     this.getCovidSummaryData();
+    regionService.getRegionObservable().subscribe(() => this.getCovidHistoricalData())
   }
 
   /**
@@ -49,7 +52,7 @@ export class CovidDataApiService {
     this.callApis(this.summaryApiServices, this.summaryDataObserver);
   }
 
-  getCovidHistoricalData(): void {
+  private getCovidHistoricalData(): void {
     this.callApis(this.historicalApiServices, this.historicalDataObserver);
   }
 

--- a/src/app/services/covid-data-api.service.ts
+++ b/src/app/services/covid-data-api.service.ts
@@ -5,11 +5,8 @@ import { Subject } from 'rxjs';
 import { CountryHistoricalDataPoint } from './externalApis/common-covid-19-api';
 import { RegionSelectService } from './region-select.service';
 
-export interface CovidDataApiSubService {
-  call(
-    successCallback: (x: any) => void,
-    errorCallback: (x?: any) => void
-  ): void;
+export interface CovidDataApiSubService { 
+  call(successCallback: (x: any) => void, errorCallback: (x?: any) => void): void;
 }
 
 export const COVID_DATA_API_SUB_SERVICE_SUMMARY = new InjectionToken<
@@ -24,12 +21,9 @@ export const COVID_DATA_API_SUB_SERVICE_HISTORICAL = new InjectionToken<
   providedIn: 'root',
 })
 export class CovidDataApiService {
-  summaryDataObserver: Subject<CovidDataPoint[]> = new Subject<
-    CovidDataPoint[]
-  >();
-  historicalDataObserver: Subject<CountryHistoricalDataPoint[]> = new Subject<
-    CountryHistoricalDataPoint[]
-  >();
+  summaryDataObserver: Subject<CovidDataPoint[]> = new Subject<CovidDataPoint[]>();
+  historicalDataObserver: Subject<CountryHistoricalDataPoint[]> = 
+    new Subject<CountryHistoricalDataPoint[]>();
 
   constructor(
     // Inspired by (https://stackoverflow.com/a/35916788)

--- a/src/app/services/covid-data-api.service.ts
+++ b/src/app/services/covid-data-api.service.ts
@@ -43,8 +43,4 @@ export class CovidDataApiService {
     );
     callFunction();
   }
-
-  private callFunction() {
-    
-  }
 }

--- a/src/app/services/date-select.service.spec.ts
+++ b/src/app/services/date-select.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DateSelectService } from './date-select.service';
+
+describe('DateSelectServiceService', () => {
+  let service: DateSelectService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DateSelectService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/date-select.service.ts
+++ b/src/app/services/date-select.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DateSelectService {
+
+  private dateRangeSelected: DateRange;
+  private subscription: Subject<DateRange>;
+
+  constructor() {
+    // TODO - Update once date selector component is created
+    const todaysDate = new Date(Date.now());
+    const twoDaysAgoDate = new Date(todaysDate);
+    twoDaysAgoDate.setUTCDate(todaysDate.getDate() - 2);
+
+    this.dateRangeSelected = {
+      to: todaysDate,
+      from: twoDaysAgoDate
+    }
+    
+    this.subscription = new Subject<DateRange>();
+  }
+
+  setDateRange(from: Date, to: Date): void {
+    this.dateRangeSelected = { from, to };
+    this.subscription.next(this.dateRangeSelected);
+  }
+
+  getDateRangeObservable(): Subject<DateRange> {
+    return this.subscription;
+  }
+
+  getDateRange(): DateRange {
+    return this.dateRangeSelected;
+  }
+}
+
+export interface DateRange {
+  from: Date;
+  to: Date;
+}

--- a/src/app/services/date-select.service.ts
+++ b/src/app/services/date-select.service.ts
@@ -11,13 +11,14 @@ export class DateSelectService {
 
   constructor() {
     // TODO - Update once date selector component is created
-    const todaysDate = new Date(Date.now());
-    const twoDaysAgoDate = new Date(todaysDate);
-    twoDaysAgoDate.setUTCDate(todaysDate.getDate() - 2);
+    const yesterdaysDate = new Date(Date.now());
+    yesterdaysDate.setUTCDate(yesterdaysDate.getDate() - 1)
+    const twoDaysBeforeDate = new Date(yesterdaysDate);
+    twoDaysBeforeDate.setUTCDate(yesterdaysDate.getDate() - 3);
 
     this.dateRangeSelected = {
-      to: todaysDate,
-      from: twoDaysAgoDate
+      to: yesterdaysDate,
+      from: twoDaysBeforeDate
     }
     
     this.subscription = new Subject<DateRange>();

--- a/src/app/services/externalApis/common-covid-19-api.ts
+++ b/src/app/services/externalApis/common-covid-19-api.ts
@@ -29,6 +29,6 @@ export interface CountryHistoricalDataPoint {
   Date: string;
 }
 
-export const toSlug = (countryName: string) => countryName.toLowerCase().replace(' ','-');
+export const date2ApiFormat = (date: Date) => `${date.toISOString().slice(0, -2)}Z`;
 
 export const BASE_URL = 'https://api.covid19api.com/';

--- a/src/app/services/externalApis/common-covid-19-api.ts
+++ b/src/app/services/externalApis/common-covid-19-api.ts
@@ -1,4 +1,4 @@
-export interface GlobalDataPoint {
+export interface GlobalSummaryDataPoint {
   NewConfirmed: number;
   TotalConfirmed: number;
   NewDeaths: number;
@@ -7,11 +7,28 @@ export interface GlobalDataPoint {
   TotalRecovered: number;
 }
 
-export interface CountryDataPoint extends GlobalDataPoint {
+export interface CountrySummaryDataPoint extends GlobalSummaryDataPoint {
   Country: string;
   CountryCode: string;
   Slug: string;
   Date: string;
 }
+
+export interface CountryHistoricalDataPoint {
+  Country: string;
+  CountryCode: string;
+  Province: string;
+  City: string;
+  CityCode: string;
+  Lat: string;
+  Lon: string;
+  Confirmed: number;
+  Deaths: number;
+  Recovered: number;
+  Active: number;
+  Date: string;
+}
+
+export const toSlug = (countryName: string) => countryName.toLowerCase().replace(' ','-');
 
 export const BASE_URL = 'https://api.covid19api.com/';

--- a/src/app/services/externalApis/common-covid-19-api.ts
+++ b/src/app/services/externalApis/common-covid-19-api.ts
@@ -1,0 +1,17 @@
+export interface GlobalDataPoint {
+  NewConfirmed: number;
+  TotalConfirmed: number;
+  NewDeaths: number;
+  TotalDeaths: number;
+  NewRecovered: number;
+  TotalRecovered: number;
+}
+
+export interface CountryDataPoint extends GlobalDataPoint {
+  Country: string;
+  CountryCode: string;
+  Slug: string;
+  Date: string;
+}
+
+export const BASE_URL = 'https://api.covid19api.com/';

--- a/src/app/services/externalApis/historical-covid-19-api.service.spec.ts
+++ b/src/app/services/externalApis/historical-covid-19-api.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HistoricalCovid19ApiService } from './historical-covid-19-api.service';
+
+describe('HistoricalCovid19ApiService', () => {
+  let service: HistoricalCovid19ApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HistoricalCovid19ApiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/externalApis/historical-covid-19-api.service.ts
+++ b/src/app/services/externalApis/historical-covid-19-api.service.ts
@@ -1,7 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { CovidDataApiSubService } from '../covid-data-api.service';
-import { GlobalDataPoint, CountryDataPoint, BASE_URL } from './common-covid-19-api';
+import { RegionSelectService } from '../region-select.service';
+import { DateSelectService } from '../date-select.service';
+import { CountryHistoricalDataPoint, BASE_URL, toSlug } from './common-covid-19-api';
+import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -9,9 +12,24 @@ import { GlobalDataPoint, CountryDataPoint, BASE_URL } from './common-covid-19-a
 export class HistoricalCovid19ApiService implements CovidDataApiSubService {
   readonly baseUrl = BASE_URL;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private regionService: RegionSelectService, private dateService: DateSelectService) {}
 
-  call(successCallback: (x: any) => void, errorCallback: (x?: any) => void): void {
-    throw new Error('Method not implemented.');
+  call(
+    successCallback: (x: any) => void, 
+    errorCallback: (x?: any) => void
+  ): void {
+    const country = this.regionService.getRegion().name;
+    const { from, to } = this.dateService.getDateRange();
+    const url = `${this.baseUrl}country/${toSlug(country)}?from=${this.date2ApiFormat(from)}&to=${this.date2ApiFormat(to)}`
+
+    this.http.get<CountryHistoricalDataPoint[]>(url)
+      .subscribe(
+        successCallback,
+        errorCallback
+    )
+  }
+
+  private date2ApiFormat(date: Date) {
+    return `${date.toISOString().slice(0, -2)}Z`;
   }
 }

--- a/src/app/services/externalApis/historical-covid-19-api.service.ts
+++ b/src/app/services/externalApis/historical-covid-19-api.service.ts
@@ -1,0 +1,17 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { CovidDataApiSubService } from '../covid-data-api.service';
+import { GlobalDataPoint, CountryDataPoint, BASE_URL } from './common-covid-19-api';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HistoricalCovid19ApiService implements CovidDataApiSubService {
+  readonly baseUrl = BASE_URL;
+
+  constructor(private http: HttpClient) {}
+
+  call(successCallback: (x: any) => void, errorCallback: (x?: any) => void): void {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/app/services/externalApis/summary-covid-19-api.service.spec.ts
+++ b/src/app/services/externalApis/summary-covid-19-api.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { Covid19ApiService, SummaryResponse } from './covid-19-api.service';
+import { SummaryCovid19ApiService, SummaryResponse } from './summary-covid-19-api.service';
 import {
   HttpClientTestingModule,
   HttpTestingController,
@@ -11,7 +11,7 @@ import { byCountryCode } from 'country-finder';
 
 
 describe('Covid19ApiService', () => {
-  let apiService: Covid19ApiService;
+  let apiService: SummaryCovid19ApiService;
   let httpTestingController: HttpTestingController;
 
   const sampleSummaryResponse: SummaryResponse = {
@@ -79,7 +79,7 @@ describe('Covid19ApiService', () => {
       imports: [HttpClientTestingModule],
     });
 
-    apiService = TestBed.inject(Covid19ApiService);
+    apiService = TestBed.inject(SummaryCovid19ApiService);
     httpTestingController = TestBed.inject(HttpTestingController);
   });
 

--- a/src/app/services/externalApis/summary-covid-19-api.service.ts
+++ b/src/app/services/externalApis/summary-covid-19-api.service.ts
@@ -4,7 +4,7 @@ import {
 } from '../covid-data-api.service';
 import { HttpClient } from '@angular/common/http';
 import { CovidDataPoint } from '../../models/CovidDataPoint';
-import { GlobalDataPoint, CountryDataPoint, BASE_URL } from './common-covid-19-api';
+import { GlobalSummaryDataPoint, CountrySummaryDataPoint, BASE_URL } from './common-covid-19-api';
 import { map } from 'rxjs/operators';
 
 @Injectable({
@@ -20,7 +20,7 @@ export class SummaryCovid19ApiService implements CovidDataApiSubService {
     errorCallback: (error?: any) => void
   ): void {
     this.http.get<SummaryResponse>(`${this.baseUrl}summary`).pipe(
-      map((response: { Countries: CountryDataPoint[] }) =>
+      map((response: { Countries: CountrySummaryDataPoint[] }) =>
         response.Countries.map(countryData =>
           new CovidDataPoint(
             countryData.CountryCode,
@@ -39,7 +39,7 @@ export class SummaryCovid19ApiService implements CovidDataApiSubService {
 }
 
 export interface SummaryResponse {
-  Global: GlobalDataPoint;
-  Countries: CountryDataPoint[];
+  Global: GlobalSummaryDataPoint;
+  Countries: CountrySummaryDataPoint[];
   Date: string;
 }

--- a/src/app/services/externalApis/summary-covid-19-api.service.ts
+++ b/src/app/services/externalApis/summary-covid-19-api.service.ts
@@ -4,13 +4,14 @@ import {
 } from '../covid-data-api.service';
 import { HttpClient } from '@angular/common/http';
 import { CovidDataPoint } from '../../models/CovidDataPoint';
+import { GlobalDataPoint, CountryDataPoint, BASE_URL } from './common-covid-19-api';
 import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
 })
-export class Covid19ApiService implements CovidDataApiSubService {
-  readonly baseUrl = 'https://api.covid19api.com/';
+export class SummaryCovid19ApiService implements CovidDataApiSubService {
+  readonly baseUrl = BASE_URL;
 
   constructor(private http: HttpClient) {}
 
@@ -35,22 +36,6 @@ export class Covid19ApiService implements CovidDataApiSubService {
       errorCallback
     );
   }
-}
-
-interface GlobalDataPoint {
-  NewConfirmed: number;
-  TotalConfirmed: number;
-  NewDeaths: number;
-  TotalDeaths: number;
-  NewRecovered: number;
-  TotalRecovered: number;
-}
-
-interface CountryDataPoint extends GlobalDataPoint {
-  Country: string;
-  CountryCode: string;
-  Slug: string;
-  Date: string;
 }
 
 export interface SummaryResponse {


### PR DESCRIPTION
Changes:
- Added placeholder date service
- Added historical data api subservice
- Renamed some of the api service names to better reflect the new scheme (api subservice for each endpoint type)
- Added subscriptions to data and region services for getting historical data

closes #22 