### PR TITLE
Feature/23 cache api calls

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
@@ -18,6 +18,8 @@ import { SummaryCovid19ApiService } from './services/externalApis/summary-covid-
 import { HistoricalCovid19ApiService } from './services/externalApis/historical-covid-19-api.service';
 import { NEWS_SERVICE, SmartableAiNewsService } from './services/news.service';
 
+import { CacheInterceptor } from './httpInterceptors/cache.interceptor';
+
 @NgModule({
   declarations: [AppComponent, CountriesTableComponent, NewsComponent, RegionSelectComponent, WorldMapComponent],
   imports: [BrowserModule,
@@ -25,6 +27,7 @@ import { NEWS_SERVICE, SmartableAiNewsService } from './services/news.service';
     FormsModule,
     HttpClientModule],
   providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: CacheInterceptor, multi: true },
     { provide: MAP_PROVIDER, useClass: OpenStreetMapProvider },
     {
       provide: COVID_DATA_API_SUB_SERVICE_SUMMARY,

--- a/src/app/httpInterceptors/cache.interceptor.spec.ts
+++ b/src/app/httpInterceptors/cache.interceptor.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CacheInterceptor } from './cache.interceptor';
+
+describe('CacheInterceptor', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [
+      CacheInterceptor
+      ]
+  }));
+
+  it('should be created', () => {
+    const interceptor: CacheInterceptor = TestBed.inject(CacheInterceptor);
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/src/app/httpInterceptors/cache.interceptor.ts
+++ b/src/app/httpInterceptors/cache.interceptor.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class CacheInterceptor implements HttpInterceptor {
+
+  constructor() {}
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    console.log("Hello from interceptor");
+    console.log(request);
+    return next.handle(request);
+  }
+}

--- a/src/app/httpInterceptors/cache.interceptor.ts
+++ b/src/app/httpInterceptors/cache.interceptor.ts
@@ -3,18 +3,32 @@ import {
   HttpRequest,
   HttpHandler,
   HttpEvent,
-  HttpInterceptor
+  HttpInterceptor, 
+  HttpResponse
 } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { ResponseCacheService } from '../services/caching/response-cache.service';
+import { tap } from 'rxjs/operators';
+
+const TIMETOLIVE = 60;
 
 @Injectable()
 export class CacheInterceptor implements HttpInterceptor {
 
-  constructor() {}
+  constructor(private cache: ResponseCacheService) {}
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    console.log("Hello from interceptor");
-    console.log(request);
-    return next.handle(request);
+    const cachedResponse = this.cache.get(request.url);
+    return cachedResponse ? of(cachedResponse) : this.sendRequest(request, next);
+  }
+
+  private sendRequest(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(request).pipe(
+      tap(event => {
+        if (event instanceof HttpResponse) {
+          this.cache.set(request.url, event, TIMETOLIVE);
+        }
+      })
+    )
   }
 }

--- a/src/app/services/caching/response-cache.service.spec.ts
+++ b/src/app/services/caching/response-cache.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ResponseCacheService } from './response-cache.service';
+
+describe('ResponseCacheService', () => {
+  let service: ResponseCacheService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ResponseCacheService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/caching/response-cache.service.ts
+++ b/src/app/services/caching/response-cache.service.ts
@@ -16,20 +16,15 @@ export class ResponseCacheService {
   get(key: string): HttpResponse<any> {
     const timedResponse = this.cache.get(key);
     if(!timedResponse) {
-      console.log("CACHE SERVICE: No cache for " + key);
-      console.log(this.cache);
       return null;
     }
     
     const expires = timedResponse.expires;
     if(expires && expires < this.nowInSeconds()) {
       this.cache.delete(key);
-      console.log("CACHE SERVICE: Expired cache for " + key);
-      console.log(this.cache);
       return null;
     }
 
-    console.log("CACHE SERVICE: Returning response for " + key);
     return timedResponse.response;
   }
 
@@ -44,8 +39,6 @@ export class ResponseCacheService {
       response
     }
     this.cache.set(key, value);
-    console.log("CACHING: " + key);
-    console.log(this.cache);
   }
 
   /**

--- a/src/app/services/caching/response-cache.service.ts
+++ b/src/app/services/caching/response-cache.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ResponseCacheService {
+  private cache = new Map<string, TimestampedResponse>();
+  
+  constructor() { }
+
+  /**
+   * @param key The request URL
+   * @returns HttpResponse if exists and not expired, otherwise null
+   */
+  get(key: string): HttpResponse<any> {
+    const timedResponse = this.cache.get(key);
+    if(!timedResponse) {
+      console.log("CACHE SERVICE: No cache for " + key);
+      console.log(this.cache);
+      return null;
+    }
+    
+    const expires = timedResponse.expires;
+    if(expires && expires < this.nowInSeconds()) {
+      this.cache.delete(key);
+      console.log("CACHE SERVICE: Expired cache for " + key);
+      console.log(this.cache);
+      return null;
+    }
+
+    console.log("CACHE SERVICE: Returning response for " + key);
+    return timedResponse.response;
+  }
+
+  /**
+   * @param key The request URL
+   * @param value The response and its expiration time
+   * @param expiresIn Number of seconds the caches items remains valid for
+   */
+  set(key: string, response: HttpResponse<any>, expiresIn: number): void {
+    const value: TimestampedResponse = {
+      expires: this.nowInSeconds() + expiresIn,
+      response
+    }
+    this.cache.set(key, value);
+    console.log("CACHING: " + key);
+    console.log(this.cache);
+  }
+
+  /**
+   * Javascripts Date.now() returns time in ms by default
+   */
+  private nowInSeconds() {
+    return Math.floor(Date.now() / 1000);
+  }
+
+}
+export interface TimestampedResponse {
+  expires: number,
+  response: HttpResponse<any>
+}


### PR DESCRIPTION
Introduces a HttpInterceptor and a cache service, which caches responses for a given URL, currently for 60 seconds.

As we don't ever make api calls after the page loads, at the moment it's difficult to see this in action, but I did test locally by adding a button hooked into the covid summary service to grab the data again and a whole bunch of console.logs(), and to the best of my knowledge I believe it works. I should probably do some unit tests or something

Currently it'll cache all responses for the set time, and there isn't a way to differentiate requests. I believe this is sufficient for now, but will need changes in the future if we ever:
 - Want live data
 - Make any requests other than GET

There is also no way to forcibly invalidate cache contents if we wanted the option to manually refresh data, however I think that's a fairly simple add if we ever need it.

Resources used: [The Angular Docs](https://angular.io/guide/http#using-interceptors-for-caching) & [this slightly outdated guide](https://nrempel.com/how-to-use-httpclient-and-httpinterceptor-to-cache-requests-in-angular-5/)

closes #23 